### PR TITLE
Fix app installation fails on Linux when ~.local/share/applications is not created

### DIFF
--- a/public/libs/install-app-async/appify-linux.sh
+++ b/public/libs/install-app-async/appify-linux.sh
@@ -33,6 +33,7 @@ mkdir -p "${HOME}/.local/share/icons";
 icon="${HOME}/.local/share/icons/webcatalog-${APPID}.png";
 cp -v "${APPPNG}" "${icon}";
 
+mkdir -p "${HOME}/.local/share/applications";
 desktopFile="$HOME/.local/share/applications/webcatalog-${APPID}.desktop";
 
 cat - > "$desktopFile" <<END


### PR DESCRIPTION
Resolve #37.