### PR TITLE
Fix new window handling error when workspace home URL is not set

### DIFF
--- a/template/public/libs/views.js
+++ b/template/public/libs/views.js
@@ -118,7 +118,7 @@ const addView = (browserWindow, workspace) => {
   });
 
   view.webContents.on('new-window', (e, nextUrl, frameName, disposition, options, additionalFeatures, referrer) => {
-    const curDomain = extractDomain(workspace.homeUrl);
+    const curDomain = extractDomain(workspace.homeUrl || appJson.url);
     const nextDomain = extractDomain(nextUrl);
 
     // load in same window


### PR DESCRIPTION
Fix this:
```
The message says "A JavaScript error occurred in the main process" and "Uncaught Exception: TypeError: Cannot read property 'match' of undefined at extractDomain (/Users/bryan/Applications/WebCatalog Apps/Gmail.app/Contents/Resources/app.asar/build/libs/views.js:26:27) at WebContents.<anonymous> (/Users/bryan/Applications/WebCatalog Apps/Gmail.app/Contents/Resources/app.asar/build/libs/views.js:121:23) at WebContents.emit (events.js:200:13```