### PR TITLE
Fix app doesn't quit properly but run in background on Windows & Linux

### DIFF
--- a/template.exclude
+++ b/template.exclude
@@ -46,7 +46,6 @@ yarn.lock
 .yarn-metadata.json
 .github
 *.map
-node_modules/*/*.html
 *.md
 *.cc
 *.h


### PR DESCRIPTION
It happens because important HTML files are removed from `node_modules`.

Resolve #544 