### PR TITLE
Fix 'screen' module can't be used before the app 'ready' event bug

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -80,6 +80,7 @@ if (!gotTheLock) {
   });
 
   app.on('activate', () => {
-    mainWindow.show();
+    app.whenReady()
+      .then(() => mainWindow.show());
   });
 }


### PR DESCRIPTION
Fix https://github.com/atomery/webcatalog/issues/721#issuecomment-615287310