### PR TITLE
Fix traffic light buttons use old outline colors when window is unfocused

### DIFF
--- a/template/src/components/main/fake-title-bar.js
+++ b/template/src/components/main/fake-title-bar.js
@@ -8,7 +8,7 @@ const titleBarHeight = 22;
 
 const styles = (theme) => ({
   root: {
-    background: theme.palette.type === 'dark' ? '#2a2b2c' : 'radial-gradient(7px at 14px 50%, #ff5e57 0px, #ff635a 5px, #fd5249 6px, rgba(255, 255, 255, 0) 7px), radial-gradient(7px at 34px 50%, #ffbd2e 0px, #ffc42f 5px, #fcb91b 6px, rgba(255, 255, 255, 0) 7px), radial-gradient(7px at 54px 50%, #cfcfcf 0px, #d3d3d3 5px, #c6c6c6 6px, rgba(255, 255, 255, 0) 7px), linear-gradient(to top, #cccccc 0%, #d6d6d6 1px, #ebebeb 100%);',
+    background: theme.palette.type === 'dark' ? '#2a2b2c' : 'linear-gradient(top, #e4e4e4, #cecece)',
     height: titleBarHeight,
     WebkitAppRegion: 'drag',
     WebkitUserSelect: 'none',


### PR DESCRIPTION
Resolve #768.