### PR TITLE
Fix installation get stuck on Windows 7

### DIFF
--- a/public/libs/app-management/check-path-in-use-async.js
+++ b/public/libs/app-management/check-path-in-use-async.js
@@ -1,12 +1,17 @@
+const os = require('os');
 const execAsync = require('../exec-async');
 
 // return true if path is in use
 // return false if path is NOT in use
 const checkPathInUseAsync = (path) => {
   if (process.platform === 'win32') {
+    // skip this check on Windows older than 10
+    // child_process never stops - powershell - windows 7
+    // https://github.com/nodejs/node/issues/25645
+
     // https://stackoverflow.com/a/9476987
     // https://stackoverflow.com/a/61219838
-    return execAsync(` get-wmiobject win32_process | ? { $_.Path -ne $null } | ? { $_.Path.Indexof('${path}') -ge 0 } | measure-object | % { $_.Count }`, { shell: 'powershell.exe' })
+    return execAsync(`get-wmiobject win32_process | ? { $_.Path -ne $null } | ? { $_.Path.Indexof('${path}') -ge 0 } | measure-object | % { $_.Count }`, { shell: 'powershell.exe' })
       .then((stdout) => {
         const processCount = parseInt(stdout, 10);
         if (processCount > 0) {

--- a/public/libs/app-management/check-path-in-use-async.js
+++ b/public/libs/app-management/check-path-in-use-async.js
@@ -5,9 +5,13 @@ const execAsync = require('../exec-async');
 // return false if path is NOT in use
 const checkPathInUseAsync = (path) => {
   if (process.platform === 'win32') {
-    // skip this check on Windows older than 10
+    // skip this check on Windows older than 10 (NT 6.x)
     // child_process never stops - powershell - windows 7
     // https://github.com/nodejs/node/issues/25645
+    // https://stackoverflow.com/questions/42524606/how-to-get-windows-version-using-node-js
+    if (os.release().startsWith('6.')) {
+      return Promise.resolve(false);
+    }
 
     // https://stackoverflow.com/a/9476987
     // https://stackoverflow.com/a/61219838


### PR DESCRIPTION
`child_process.exec` never stops when using with old version of `powershell.exe`.

Ref: https://github.com/nodejs/node/issues/25645