### PR TITLE
Fix Firefox/Chromium-based apps don't run correctly on macOS Big Sur

### DIFF
--- a/public/libs/app-management/install-app-async/forked-script-lite-v2.js
+++ b/public/libs/app-management/install-app-async/forked-script-lite-v2.js
@@ -315,7 +315,7 @@ cd Resources;
 
 cp "$PWD"/icon.icns "$PWD"/${addSlash(name)}.app/Contents/Resources/firefox.icns
 
-open "$PWD"/${addSlash(name)}.app --args ${urlParam} -P ${firefoxProfileId}
+open -n "$PWD"/${addSlash(name)}.app --args ${urlParam} -P ${firefoxProfileId}
 `;
           } else if (useTabs) {
             execFileContent = `#!/bin/sh
@@ -344,7 +344,7 @@ else
   Tabs="${url || ''}"
 fi
 
-open "$PWD"/${addSlash(name)}.app --args $Tabs --no-sandbox --test-type --user-data-dir="$HOME"/Library/Application\\ Support/WebCatalog/ChromiumProfiles/${id}
+open -n "$PWD"/${addSlash(name)}.app --args $Tabs --no-sandbox --test-type --user-data-dir="$HOME"/Library/Application\\ Support/WebCatalog/ChromiumProfiles/${id}
 `;
           } else {
             execFileContent = `#!/bin/sh
@@ -366,7 +366,7 @@ if [ -n "$pgrepResult" ]; then
   exit
 fi
 
-open "$PWD"/${addSlash(name)}.app --args --no-sandbox --test-type --app="${url}" --user-data-dir="$HOME"/Library/Application\\ Support/WebCatalog/ChromiumProfiles/${id}
+open -n "$PWD"/${addSlash(name)}.app --args --no-sandbox --test-type --app="${url}" --user-data-dir="$HOME"/Library/Application\\ Support/WebCatalog/ChromiumProfiles/${id}
 `;
           }
           return fsExtra.outputFile(execFilePath, execFileContent)

--- a/public/libs/app-management/install-app-async/forked-script-lite-v2.js
+++ b/public/libs/app-management/install-app-async/forked-script-lite-v2.js
@@ -510,7 +510,7 @@ open -n "$PWD"/${addSlash(name)}.app --args --no-sandbox --test-type --app="${ur
   })
   .then(() => {
     const packageJson = JSON.stringify({
-      version: '2.5.0',
+      version: '2.6.0',
     });
     return fsExtra.writeFileSync(packageJsonPath, packageJson);
   })

--- a/public/libs/app-management/install-app-async/index.js
+++ b/public/libs/app-management/install-app-async/index.js
@@ -79,7 +79,7 @@ const installAppAsync = (
       if (process.platform === 'darwin') {
         // use v2 script on Mac
         scriptFileName = 'forked-script-lite-v2.js';
-        v = '2.5.0';
+        v = '2.6.0';
       } else {
         scriptFileName = 'forked-script-lite-v1.js';
         v = '1.1.0';

--- a/src/state/app-management/utils.js
+++ b/src/state/app-management/utils.js
@@ -27,7 +27,7 @@ export const isOutdatedApp = (id, state) => {
   if (apps[id].engine !== 'electron') {
     // check if app is installed with the latest version of forked-script-v2.js
     if (window.process.platform === 'darwin') {
-      return semver.lt(v, '2.5.0');
+      return semver.lt(v, '2.6.0');
     }
     // check if app is installed with the latest version of forked-script-v1.js
     return semver.lt(v, '1.1.0');


### PR DESCRIPTION
@scottrbaxter

macOS Big Sur changes the default behavior of `open` command. By default, `open` will focus on the opened app window instead opening a new instance (what we expect). Adding `-n` as suggested by @scottrbaxter resolves this.
> -n Open a new instance of the application(s) even if one is already running.
