### PR TITLE
Fix ICNS icon is corrupted during installation

### DIFF
--- a/patches/icon-gen+2.0.0.patch
+++ b/patches/icon-gen+2.0.0.patch
@@ -1,0 +1,121 @@
+diff --git a/node_modules/icon-gen/dist/lib/icns-generator.js b/node_modules/icon-gen/dist/lib/icns-generator.js
+index 6cc349f..fc9e42e 100755
+--- a/node_modules/icon-gen/dist/lib/icns-generator.js
++++ b/node_modules/icon-gen/dist/lib/icns-generator.js
+@@ -225,56 +225,61 @@ const createIconBlockPackBits = (id, mask, data) => {
+ 
+ 
+ const createIcon = (images, dest) => {
+-  // Write a temporary file size
+-  let fileSize = HEADER_SIZE;
++  return new Promise((resolve) => {
++    // Write a temporary file size
++    let fileSize = HEADER_SIZE;
+ 
+-  let stream = _fs.default.createWriteStream(dest);
+ 
+-  stream.write(createFileHeader(fileSize), 'binary');
++    let stream = _fs.default.createWriteStream(dest);
+ 
+-  for (let i = 0, max = ICON_INFOS.length; i < max; ++i) {
+-    const info = ICON_INFOS[i];
+-    const image = imageFromIconSize(info.size, images);
++    // https://stackoverflow.com/questions/46752428/do-i-need-await-fs-createwritestream-in-pipe-method-in-node
++    stream.on('finish', () => resolve(true));
+ 
+-    if (!image) {
+-      // Depending on the command line option, there may be no corresponding size
+-      continue;
+-    }
++    stream.write(createFileHeader(fileSize), 'binary');
+   
+-    let block = null;
++    for (let i = 0, max = ICON_INFOS.length; i < max; ++i) {
++      const info = ICON_INFOS[i];
++      const image = imageFromIconSize(info.size, images);
+   
+-    switch (info.id) {
+-      case 'is32':
+-      case 'il32':
+-        block = createIconBlockPackBits(info.id, info.mask, _fs.default.readFileSync(image.path));
+-        break;
++      if (!image) {
++        // Depending on the command line option, there may be no corresponding size
++        continue;
++      }
+   
+-      default:
+-        block = createIconBlock(info.id, _fs.default.readFileSync(image.path));
+-        break;
+-    }
++      let block = null;
+   
+-    if (block) {
+-      stream.write(block, 'binary');
+-      fileSize += block.length;
+-    } else {
+-      fileSize = 0;
+-      break;
+-    }
+-  }
++      switch (info.id) {
++        case 'is32':
++        case 'il32':
++          block = createIconBlockPackBits(info.id, info.mask, _fs.default.readFileSync(image.path));
++          break;
+   
+-  stream.end();
++        default:
++          block = createIconBlock(info.id, _fs.default.readFileSync(image.path));
++          break;
++      }
+   
+-  if (fileSize === 0) {
+-    return false;
+-  } // Update an actual file size
++      if (block) {
++        stream.write(block, 'binary');
++        fileSize += block.length;
++      } else {
++        fileSize = 0;
++        break;
++      }
++    }
++  
++    stream.end();
+   
++    if (fileSize === 0) {
++      resolve(false);
++    } // Update an actual file size
+   
+-  stream = _fs.default.createWriteStream(dest);
+-  stream.write(createFileHeader(fileSize), 'binary');
+-  stream.end();
+-  return true;
++    stream = _fs.default.createWriteStream(dest);
++    stream.write(createFileHeader(fileSize), 'binary');
++    stream.end();
++  })
+ };
++
+ /**
+  * Check an option properties.
+  * @param {Object} options Output destination the path of directory.
+@@ -354,7 +359,7 @@ const GetRequiredICNSImageSizes = () => {
+ exports.GetRequiredICNSImageSizes = GetRequiredICNSImageSizes;
+ 
+ const GenerateICNS = (images, dir, options, logger) => {
+-  return new _es6Promise.Promise((resolve, reject) => {
++  return new _es6Promise.Promise(async (resolve, reject) => {
+     logger.log('ICNS:');
+     const opt = checkOptions(options);
+ 
+@@ -362,7 +367,7 @@ const GenerateICNS = (images, dir, options, logger) => {
+ 
+     const targets = _util.default.filterImagesBySizes(images, opt.sizes);
+ 
+-    if (createIcon(targets, dest)) {
++    if (await createIcon(targets, dest)) {
+       logger.log('  Create: ' + dest);
+       resolve(dest);
+     } else {

--- a/public/libs/app-management/install-app-async/forked-script-electron-v2.js
+++ b/public/libs/app-management/install-app-async/forked-script-electron-v2.js
@@ -24,7 +24,6 @@ const Jimp = process.env.NODE_ENV === 'production' ? require('jimp').default : r
 const isUrl = require('is-url');
 const sudo = require('sudo-prompt');
 const ProxyAgent = require('proxy-agent');
-const hasha = require('hasha');
 
 const execAsync = require('../../exec-async');
 const downloadAsync = require('../../download-async');
@@ -181,7 +180,22 @@ Promise.resolve()
               name: 'e',
               sizes,
             },
-          });
+          })
+            .then(() => {
+              // icon-gen promise is resolved before the icon is generated
+              // the bug is patched but this test is kept to check everything in check
+              // (make sure ICNS file size at least as big as original PNG file)
+              // see https://github.com/webcatalog/webcatalog-app/issues/1185
+              // see https://github.com/electron/electron-packager/issues/691
+              if (process.platform === 'darwin') {
+                const icnsFileSize = fsExtra.statSync(iconIcnsPath).size;
+                const pngFileSize = fsExtra.statSync(iconPngPath).size;
+                if (icnsFileSize < pngFileSize) {
+                  return Promise.reject(new Error('e.icns is corrupted (file size is smaller than e.png).'));
+                }
+              }
+              return null;
+            });
         }
         if (process.platform === 'win32') {
           return icongen(buildResourcesPath, buildResourcesPath, {
@@ -311,23 +325,6 @@ Promise.resolve()
       : path.join(dotTemplatePath, 'resources');
     const outputAppAsarUnpackedPath = path.join(resourcesPath, 'app.asar.unpacked');
     return fsExtra.copy(appAsarUnpackedPath, outputAppAsarUnpackedPath, { overwrite: true });
-  })
-  .then(() => {
-    // for unknown reason, on some Macs (electron-package only copies the icon)
-    // electron.icns is corrupted after copying by electron-packager
-    // validate to be sure it's not corrupted
-    // see https://github.com/webcatalog/webcatalog-app/issues/1185
-    // see https://github.com/electron/electron-packager/issues/691
-    if (process.platform === 'darwin') {
-      const destIcnsPath = path.join(dotTemplatePath, 'Contents', 'Resources', 'electron.icns');
-      if (hasha.fromFileSync(destIcnsPath) !== hasha.fromFileSync(iconIcnsPath)) {
-        return Promise.reject(new Error('electron.icns is corrupted when copying.'));
-      }
-      if (fsExtra.statSync(destIcnsPath).size < 100) {
-        return Promise.reject(new Error('electron.icns is corrupted (file size is too small).'));
-      }
-    }
-    return null;
   })
   .then(async () => {
     // eslint-disable-next-line no-console

--- a/public/libs/app-management/install-app-async/forked-script-lite-v2.js
+++ b/public/libs/app-management/install-app-async/forked-script-lite-v2.js
@@ -278,7 +278,22 @@ Promise.resolve()
               name: 'e',
               sizes,
             },
-          });
+          })
+            .then(() => {
+              // icon-gen promise is resolved before the icon is generated
+              // the bug is patched but this test is kept to check everything in check
+              // (make sure ICNS file size at least as big as original PNG file)
+              // see https://github.com/webcatalog/webcatalog-app/issues/1185
+              // see https://github.com/electron/electron-packager/issues/691
+              if (process.platform === 'darwin') {
+                const icnsFileSize = fsExtra.statSync(iconIcnsPath).size;
+                const pngFileSize = fsExtra.statSync(iconPngPath).size;
+                if (icnsFileSize < pngFileSize) {
+                  return Promise.reject(new Error('e.icns is corrupted (file size is smaller than e.png).'));
+                }
+              }
+              return null;
+            });
         }
         return null;
       });


### PR DESCRIPTION
Fix #1185.

Patch `icon-gen` temporarily, awaiting for https://github.com/akabekobeko/npm-icon-gen/pull/124 to be merged.