### PR TITLE
Show spaces in catalog page

### DIFF
--- a/src/components/pages/home/index.js
+++ b/src/components/pages/home/index.js
@@ -81,9 +81,6 @@ const Container = ({
         alwaysSearchOnInitialLoad: true,
         trackUrlState: true,
         searchQuery: {
-          filters: [
-            { field: 'type', values: ['Singlesite'], type: 'all' },
-          ],
           resultsPerPage: 82,
           result_fields: {
             id: { raw: {} },


### PR DESCRIPTION
Reason: Users were confused as they couldn't find "Singlebox" in the catalog page.